### PR TITLE
[Fixed] `rails g`コマンドの際にassetsファイル、helperが作成されないように改善

### DIFF
--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -2,7 +2,7 @@ class ImageUploader < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
   storage :file
   process :resize_to_limit => [500, 500] 
-  storage :file
+  
   def store_dir
     "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,9 +11,9 @@ module SampleF
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
 
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration can go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded after loading
-    # the framework and any gems in your application.
+    config.generators do |g|
+      g.assets false
+      g.helper false
+    end
   end
 end


### PR DESCRIPTION
#1 
General options:
  -h, [--help]     # Print generator's options and usage
  -p, [--pretend]  # Run but do not make any changes
  -f, [--force]    # Overwrite files that already exist
  -s, [--skip]     # Skip files that already exist
  -q, [--quiet]    # Suppress status output

Please choose a generator below.

Rails:
  application_record
  assets
  channel
  controller
  generator
  helper
  integration_test
  jbuilder
  job
  mailer
  migration
  model
  resource
  scaffold
  scaffold_controller
  system_test
  task

ActiveRecord:
  active_record:application_record

Coffee:
  coffee:assets

Js:
  js:assets

TestUnit:
  test_unit:generator

  test_unit:plugin

Uploader:
  uploaderコマンドの際にいらないファイルが生成されないようにした